### PR TITLE
Serialize byteslice types in borsh-rs

### DIFF
--- a/borsh-rs/borsh-derive-internal/src/struct_ser.rs
+++ b/borsh-rs/borsh-derive-internal/src/struct_ser.rs
@@ -42,7 +42,7 @@ pub fn struct_ser(input: &ItemStruct) -> syn::Result<TokenStream2> {
     }
     Ok(quote! {
         impl #generics borsh::ser::BorshSerialize for #name #generics where #serializable_field_types {
-            fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+            fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::result::Result<(), std::io::Error> {
                 #body
                 Ok(())
             }
@@ -76,7 +76,7 @@ mod tests {
                 u64: borsh::ser::BorshSerialize,
                 String: borsh::ser::BorshSerialize,
             {
-                fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+                fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::result::Result<(), std::io::Error> {
                     borsh::BorshSerialize::serialize(&self.x, writer)?;
                     borsh::BorshSerialize::serialize(&self.y, writer)?;
                     Ok(())
@@ -102,7 +102,7 @@ mod tests {
                 HashMap<K, V>: borsh::ser::BorshSerialize,
                 String: borsh::ser::BorshSerialize,
             {
-                fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+                fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::result::Result<(), std::io::Error> {
                     borsh::BorshSerialize::serialize(&self.x, writer)?;
                     borsh::BorshSerialize::serialize(&self.y, writer)?;
                     Ok(())

--- a/borsh-rs/borsh/src/ser/mod.rs
+++ b/borsh-rs/borsh/src/ser/mod.rs
@@ -105,17 +105,15 @@ impl BorshSerialize for &str {
     }
 }
 
-impl BorshSerialize for [u8] {
-    #[inline]
+#[cfg(feature = "std")]
+impl<T: BorshSerialize> BorshSerialize for Vec<T>
+{
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        writer.write_all(&(self.len() as u32).to_le_bytes())?;
-        writer.write_all(self)?;
-        Ok(())
+        self.as_slice().serialize(writer)
     }
 }
 
-#[cfg(feature = "std")]
-impl<T> BorshSerialize for Vec<T>
+impl<T> BorshSerialize for [T]
 where
     T: BorshSerialize,
 {

--- a/borsh-rs/borsh/src/ser/mod.rs
+++ b/borsh-rs/borsh/src/ser/mod.rs
@@ -127,6 +127,12 @@ where
     }
 }
 
+impl<T: BorshSerialize> BorshSerialize for &T {
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        (*self).serialize(writer)
+    }
+}
+
 #[cfg(feature = "std")]
 impl<T> BorshSerialize for HashSet<T>
 where
@@ -235,6 +241,12 @@ impl BorshSerialize for Box<[u8]> {
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         (self.len() as u32).serialize(writer)?;
         writer.write_all(self)
+    }
+}
+
+impl<T: BorshSerialize> BorshSerialize for Box<T> {
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        (&**self).serialize(writer)
     }
 }
 

--- a/borsh-rs/borsh/src/ser/mod.rs
+++ b/borsh-rs/borsh/src/ser/mod.rs
@@ -15,6 +15,12 @@ pub trait BorshSerialize {
     }
 }
 
+impl BorshSerialize for () {
+    fn serialize<W: Write>(&self, _writer: &mut W) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
 impl BorshSerialize for u8 {
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
@@ -88,10 +94,22 @@ where
 }
 
 impl BorshSerialize for String {
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        self.as_bytes().serialize(writer)
+    }
+}
+
+impl BorshSerialize for &str {
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+        self.as_bytes().serialize(writer)
+    }
+}
+
+impl BorshSerialize for [u8] {
     #[inline]
     fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         writer.write_all(&(self.len() as u32).to_le_bytes())?;
-        writer.write_all(self.as_bytes())?;
+        writer.write_all(self)?;
         Ok(())
     }
 }


### PR DESCRIPTION
This PR
* adds support for byteslice-like serialization
* adds support for `()`, as per the spec in the README
* adds support for serializing reference types (e.g. `Option<&String>`)
* resolves #43 
* resolves #19 (I think?)