### PR TITLE
Improve array deserialization

### DIFF
--- a/borsh-rs/Cargo.lock
+++ b/borsh-rs/Cargo.lock
@@ -64,6 +64,8 @@ name = "borsh-derive"
 version = "0.2.9"
 dependencies = [
  "borsh-derive-internal 0.2.9",
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/borsh-rs/borsh-derive-internal/src/lib.rs
+++ b/borsh-rs/borsh-derive-internal/src/lib.rs
@@ -7,6 +7,7 @@ mod struct_de;
 mod struct_ser;
 mod union_de;
 mod union_ser;
+mod util;
 
 pub use enum_de::enum_de;
 pub use enum_ser::enum_ser;

--- a/borsh-rs/borsh-derive-internal/src/struct_ser.rs
+++ b/borsh-rs/borsh-derive-internal/src/struct_ser.rs
@@ -5,9 +5,7 @@ use syn::{Fields, Index, ItemStruct};
 
 pub fn struct_ser(input: &ItemStruct) -> syn::Result<TokenStream2> {
     let name = &input.ident;
-    let generics = &input.generics;
     let mut body = TokenStream2::new();
-    let mut serializable_field_types = TokenStream2::new();
     match &input.fields {
         Fields::Named(fields) => {
             for field in &fields.named {
@@ -19,11 +17,6 @@ pub fn struct_ser(input: &ItemStruct) -> syn::Result<TokenStream2> {
                     borsh::BorshSerialize::serialize(&self.#field_name, writer)?;
                 };
                 body.extend(delta);
-
-                let field_type = &field.ty;
-                serializable_field_types.extend(quote!{
-                    #field_type: borsh::ser::BorshSerialize,
-                });
             }
         }
         Fields::Unnamed(fields) => {
@@ -40,9 +33,13 @@ pub fn struct_ser(input: &ItemStruct) -> syn::Result<TokenStream2> {
         }
         Fields::Unit => {}
     }
+
+    let generics = crate::util::add_ser_constraints(input.generics.clone());
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
     Ok(quote! {
-        impl #generics borsh::ser::BorshSerialize for #name #generics where #serializable_field_types {
-            fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+        impl #impl_generics borsh::ser::BorshSerialize for #name #ty_generics #where_clause {
+            fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::result::Result<(), std::io::Error> {
                 #body
                 Ok(())
             }
@@ -71,12 +68,8 @@ mod tests {
 
         let actual = struct_ser(&item_struct).unwrap();
         let expected = quote!{
-            impl borsh::ser::BorshSerialize for A
-            where
-                u64: borsh::ser::BorshSerialize,
-                String: borsh::ser::BorshSerialize,
-            {
-                fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+            impl borsh::ser::BorshSerialize for A {
+                fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::result::Result<(), std::io::Error> {
                     borsh::BorshSerialize::serialize(&self.x, writer)?;
                     borsh::BorshSerialize::serialize(&self.y, writer)?;
                     Ok(())
@@ -97,12 +90,8 @@ mod tests {
 
         let actual = struct_ser(&item_struct).unwrap();
         let expected = quote!{
-            impl<K, V> borsh::ser::BorshSerialize for A<K, V>
-            where
-                HashMap<K, V>: borsh::ser::BorshSerialize,
-                String: borsh::ser::BorshSerialize,
-            {
-                fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+            impl<K: borsh::ser::BorshSerialize, V: borsh::ser::BorshSerialize> borsh::ser::BorshSerialize for A<K, V> {
+                fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::result::Result<(), std::io::Error> {
                     borsh::BorshSerialize::serialize(&self.x, writer)?;
                     borsh::BorshSerialize::serialize(&self.y, writer)?;
                     Ok(())
@@ -112,4 +101,3 @@ mod tests {
         assert_eq(expected, actual);
     }
 }
-

--- a/borsh-rs/borsh-derive-internal/src/util.rs
+++ b/borsh-rs/borsh-derive-internal/src/util.rs
@@ -1,0 +1,15 @@
+use syn::{Generics, parse_quote};
+
+pub fn add_ser_constraints(mut generics: Generics) -> Generics {
+    for type_param in generics.type_params_mut() {
+        type_param.bounds.push(parse_quote!(borsh::ser::BorshSerialize));
+    }
+    generics
+}
+
+pub fn add_de_constraints(mut generics: Generics) -> Generics {
+    for type_param in generics.type_params_mut() {
+        type_param.bounds.push(parse_quote!(borsh::de::BorshDeserialize));
+    }
+    generics
+}

--- a/borsh-rs/borsh-derive/Cargo.toml
+++ b/borsh-rs/borsh-derive/Cargo.toml
@@ -17,5 +17,6 @@ proc-macro = true
 
 [dependencies]
 borsh-derive-internal = { path = "../borsh-derive-internal" , version="0.2.9"}
+proc-macro2 = "1.0"
+quote = "1.0"
 syn = {version = "1", features = ["full", "fold"] }
-

--- a/borsh-rs/borsh-derive/src/lib.rs
+++ b/borsh-rs/borsh-derive/src/lib.rs
@@ -2,7 +2,8 @@ extern crate proc_macro;
 
 use borsh_derive_internal::*;
 use proc_macro::TokenStream;
-use syn::{ItemEnum, ItemStruct, ItemUnion};
+use quote::{quote, format_ident};
+use syn::{parse_macro_input, Ident, ItemEnum, ItemStruct, ItemUnion, LitInt, Token};
 
 #[proc_macro_derive(BorshSerialize, attributes(borsh_skip))]
 pub fn borsh_serialize(input: TokenStream) -> TokenStream {
@@ -38,4 +39,67 @@ pub fn borsh_deserialize(input: TokenStream) -> TokenStream {
         Ok(res) => res,
         Err(err) => err.to_compile_error(),
     })
+}
+
+struct SeqMacroSpec {
+    mac_ident: Ident,
+    prefix: Option<Ident>,
+    lengths: Vec<usize>,
+}
+
+impl syn::parse::Parse for SeqMacroSpec {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mac_ident = input.parse()?;
+        input.parse::<Token![=>]>()?;
+
+        let prefix = input.parse::<Option<Ident>>()?;
+        if prefix.is_some() {
+            input.parse::<Token![::]>()?;
+        }
+
+        let seq_lengths;
+        syn::parenthesized!(seq_lengths in input);
+        let punctuated_lengths: syn::punctuated::Punctuated<LitInt, syn::parse::Nothing> =
+            seq_lengths.parse_terminated(LitInt::parse)?;
+        let lengths = punctuated_lengths
+            .iter()
+            .map(|l| l.base10_parse::<usize>())
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(SeqMacroSpec {
+            mac_ident,
+            prefix,
+            lengths,
+        })
+    }
+}
+
+#[proc_macro]
+#[doc(hidden)]
+pub fn _gen_seq_macro(input: TokenStream) -> TokenStream {
+    let SeqMacroSpec {
+        mac_ident,
+        prefix,
+        lengths,
+    } = parse_macro_input!(input as SeqMacroSpec);
+    let seqs = lengths.iter().copied().map(|len| {
+        (0..len)
+            .map(|i| {
+                if let Some(prefix) = &prefix {
+                    let seq_ident = format_ident!("{}{}", prefix, i);
+                    quote!(#seq_ident)
+                } else {
+                    let seq_lit = proc_macro2::Literal::usize_unsuffixed(i);
+                    quote!(#seq_lit)
+                }
+            })
+            .collect::<Vec<_>>()
+    });
+    let length_lits = lengths
+        .iter()
+        .map(|&i| proc_macro2::Literal::usize_unsuffixed(i));
+    let ts = TokenStream::from(quote! {
+        #mac_ident!(#(#length_lits => ( #(#seqs)* ))*);
+    });
+    ts
 }

--- a/borsh-rs/borsh/src/de/mod.rs
+++ b/borsh-rs/borsh/src/de/mod.rs
@@ -24,6 +24,12 @@ pub trait BorshDeserialize: Sized {
     }
 }
 
+impl BorshDeserialize for () {
+    fn deserialize<R: Read>(_reader: &mut R) -> Result<Self, Error> {
+        Ok(())
+    }
+}
+
 impl BorshDeserialize for u8 {
     #[inline]
     fn deserialize<R: Read>(reader: &mut R) -> Result<Self, Error> {

--- a/borsh-rs/borsh/src/lib.rs
+++ b/borsh-rs/borsh/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(specialization)]
+
 pub use borsh_derive::{BorshDeserialize, BorshSerialize};
 
 pub mod de;

--- a/borsh-rs/borsh/src/lib.rs
+++ b/borsh-rs/borsh/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(specialization)]
-
 pub use borsh_derive::{BorshDeserialize, BorshSerialize};
 
 pub mod de;

--- a/borsh-rs/borsh/tests/test_de_errors.rs
+++ b/borsh-rs/borsh/tests/test_de_errors.rs
@@ -70,5 +70,5 @@ fn test_nan_float() {
 fn test_evil_bytes() {
     // test takes a really long time if read() is used instead of read_exact()
     let bytes = vec![255, 255, 255, 255];
-    assert_eq!(<Vec<[u8;32]>>::try_from_slice(&bytes).unwrap_err().to_string(), "failed to fill whole buffer");
+    assert_eq!(<Vec<[u8;32]>>::try_from_slice(&bytes).unwrap_err().to_string(), "error deserializing element at index 0: failed to fill whole buffer");
 }


### PR DESCRIPTION
This PR
- [x] fixes a bug with `cargo clippy` interop caused by vacuous type constraints by only constraining _generic_ type arguments ([gist](https://gist.github.com/nhynes/6daa60d49e41b6cd0ca233684b538e7f))
- [x] adds deserialization for generic arrays
- [ ] needs tests