### PR TITLE
Use io::Result<T> type for BorshSerialize and BorshDeserialize traits

### DIFF
--- a/borsh-rs/borsh/src/schema_helpers.rs
+++ b/borsh-rs/borsh/src/schema_helpers.rs
@@ -1,15 +1,15 @@
 use crate::schema::BorshSchemaContainer;
 use crate::{BorshDeserialize, BorshSchema, BorshSerialize};
-use std::io::{Error, ErrorKind};
+use std::io;
 
 /// Deserialize this instance from a slice of bytes, but assume that at the beginning we have
 /// bytes describing the schema of the type. We deserialize this schema and verify that it is
 /// correct.
-pub fn try_from_slice_with_schema<T: BorshDeserialize + BorshSchema>(v: &[u8]) -> Result<T, Error> {
+pub fn try_from_slice_with_schema<T: BorshDeserialize + BorshSchema>(v: &[u8]) -> io::Result<T> {
     let (schema, object) = <(BorshSchemaContainer, T)>::try_from_slice(v)?;
     if T::schema_container() != schema {
-        return Err(Error::new(
-            ErrorKind::InvalidData,
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
             "Borsh schema does not match",
         ));
     }
@@ -18,9 +18,7 @@ pub fn try_from_slice_with_schema<T: BorshDeserialize + BorshSchema>(v: &[u8]) -
 
 /// Serialize object into a vector of bytes and prefix with the schema serialized as vector of
 /// bytes in Borsh format.
-pub fn try_to_vec_with_schema<T: BorshSerialize + BorshSchema>(
-    value: &T,
-) -> Result<Vec<u8>, Error> {
+pub fn try_to_vec_with_schema<T: BorshSerialize + BorshSchema>(value: &T) -> io::Result<Vec<u8>> {
     let schema = T::schema_container();
     let mut res = schema.try_to_vec()?;
     res.extend(value.try_to_vec()?);


### PR DESCRIPTION
Use of `io::Result<T>` generic type as a return type for BorshSerialize and BorshDeserialize traits which improves readability.