### PR TITLE
fix: Increase sleep time for publish

### DIFF
--- a/borsh-rs/publish.sh
+++ b/borsh-rs/publish.sh
@@ -6,6 +6,6 @@ pushd ./${p}
 cargo publish
 popd
 # Sleep a bit to let the previous package upload to crates.io. Otherwise we fail publishing checks.
-sleep 10
+sleep 30
 done
 


### PR DESCRIPTION
10 seconds is not enough. Sometimes the crate is not published within 10 sec. 30 seconds worked so far all the time.