### PR TITLE
Fix generic bounds

### DIFF
--- a/borsh-rs/borsh-derive-internal/src/struct_ser.rs
+++ b/borsh-rs/borsh-derive-internal/src/struct_ser.rs
@@ -83,7 +83,7 @@ mod tests {
             impl borsh::ser::BorshSerialize for A
             where
                 u64: borsh::ser::BorshSerialize,
-                String: borsh::ser::BorshSerialize,
+                String: borsh::ser::BorshSerialize
             {
                 fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::result::Result<(), std::io::Error> {
                     borsh::BorshSerialize::serialize(&self.x, writer)?;
@@ -109,7 +109,7 @@ mod tests {
             impl<K, V> borsh::ser::BorshSerialize for A<K, V>
             where
                 HashMap<K, V>: borsh::ser::BorshSerialize,
-                String: borsh::ser::BorshSerialize,
+                String: borsh::ser::BorshSerialize
             {
                 fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::result::Result<(), std::io::Error> {
                     borsh::BorshSerialize::serialize(&self.x, writer)?;


### PR DESCRIPTION
The derive macro currently produces invalid code when given generics with bounds like this:

```rust
#[derive(BorshDeserialize, BorshSerialize)]
struct Foo<T: Bar> {
    t: T,
}
```

This PR uses syn's [`split_for_impl`](https://docs.rs/syn/1/syn/struct.Generics.html#method.split_for_impl) to correctly handle these cases.