### PR TITLE
feat: include big integer spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,33 @@ Formal specification:
       <td>little_endian(x)</td>
     </tr>
     <tr>
+      <td>Unsigned big integers</td>
+      <td>integer_type: ["BigUint" ]</td>
+      <td>
+        bytes = little_endian(x).trim_trailing_zeroes()<br/>
+        bytes_length = <a href="https://github.com/multiformats/unsigned-varint">unsigned_varint</a>(bytes.len() as u32)<br/>
+        for byte in bytes_length <br/>
+        &nbsp; repr(byte as u8)<br/>
+        for byte in bytes <br/>
+        &nbsp; repr(byte as u8)
+      </td>
+    </tr>
+    <tr>
+      <td>Signed big integers</td>
+      <td>integer_type: ["BigInt" ]</td>
+      <td>
+        if x &equals;&equals; 0 {<br/>
+        &nbsp; repr(1 as u8)<br/>
+        } else if x &lt; 0 {<br/>
+        &nbsp; repr(0 as u8) <br/>
+        &nbsp; repr(x.magnitude() as BigUint) <br/>
+        } else {
+        &nbsp; repr(2 as u8) <br/>
+        &nbsp; repr(x.magnitude() as BigUint) <br/>
+        }
+      </td>
+    </tr>
+    <tr>
       <td>Floats</td>
       <td>float_type: ["f32" | "f64" ]</td>
       <td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -354,6 +354,33 @@ fn test_simple_struct() {
                     <td>little_endian(x)</td>
                   </tr>
                   <tr>
+                    <td>Unsigned big integers</td>
+                    <td>integer_type: ["BigUint" ]</td>
+                    <td>
+                      bytes = little_endian(x).trim_trailing_zeroes()<br/>
+                      bytes_length = <a href="https://github.com/multiformats/unsigned-varint">unsigned_varint</a>(bytes.len() as u32)<br/>
+                      for byte in bytes_length <br/>
+                      &nbsp; repr(byte as u8)<br/>
+                      for byte in bytes <br/>
+                      &nbsp; repr(byte as u8)
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Signed big integers</td>
+                    <td>integer_type: ["BigInt" ]</td>
+                    <td>
+                      if x &equals;&equals; 0 {<br/>
+                      &nbsp; repr(1 as u8)<br/>
+                      } else if x &lt; 0 {<br/>
+                      &nbsp; repr(0 as u8) <br/>
+                      &nbsp; repr(x.magnitude() as BigUint) <br/>
+                      } else {
+                      &nbsp; repr(2 as u8) <br/>
+                      &nbsp; repr(x.magnitude() as BigUint) <br/>
+                      }
+                    </td>
+                  </tr>
+                  <tr>
                     <td>Floats</td>
                     <td>float_type: ["f32" | "f64" ]</td>
                     <td>err_if_nan(x)<br />little_endian(x as integer_type)</td>


### PR DESCRIPTION
So this currently matches the functionality in https://github.com/near/borsh-rs/pull/109, but I do have one alternative for BigInt I'd like to propose (this doesn't compile):

```rust
let bytes = x.magnitude().to_le_bytes().trim_trailing_zeroes();
let scale = if x.is_negative() { -(bytes.len() as i64) } else { bytes.len() as i64 };
write_all(unsigned_varint::u64::encode(zigzag(scale));
write_all(bytes)
```

Which is more compact because it encodes the sign within the varint encoding, meaning you don't use a full byte for a value that can only be {0, 1, 2} (2 bits max). The reason I didn't originally do this was that it increased complexity by introducing zigzag encoding, mixing semantics around the sign and length of encoded bytes, and not re-using the BigUint semantics. Let me know what you think @frol @matklad if you think this is worth it for borsh.

> Rationale for zigzag is to keep the distribution of small numbers close to 0, rather than negative values starting from u64::MAX

For comparison, the values would look like:

| value | separate byte | combined  |
|-------|---------------|-----------|
| 0     | [1]           | [0]       |
| -1    | [0, 1, 1]     | [1, 1]    |
| 1     | [2, 1, 1]     | [2, 1]    |
| 257   | [2, 2, 1, 1]  | [4, 1, 1] |

And it should be more condensed (or equal when zigzag encoding increases in byte before the abs value does)