### PR TITLE
Add `Result` in the specification

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -455,6 +455,19 @@ fn test_simple_struct() {
                     </td>
                   </tr>
                   <tr>
+                    <td>Result</td>
+                    <td>result_type: "Result&lt;" ident '&gt;'</td>
+                    <td>
+                      if x.is_ok() { <br />
+                      &nbsp; repr(1 as u8) <br />
+                      &nbsp; repr(x.unwrap() as ident) <br />
+                      } else { <br />
+                      &nbsp; repr(0 as u8) <br />
+                      &nbsp; repr(x.unwrap_err() as ident) <br />
+                      }
+                    </td>
+                  </tr>
+                  <tr>
                     <td>String</td>
                     <td>string_type: "String"</td>
                     <td>


### PR DESCRIPTION
The `Result` specification is missing.
There is a section for `enum` which takes variants in the ascending order, but it doesn't apply to `Result` because `Ok` is `1` and `Err` is `0` while if we look at the core docs https://doc.rust-lang.org/src/core/result.rs.html#502, it's the opposite.