### PR TITLE
List the Ruby implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Why do we need yet another serialization format? Borsh is the first serializer t
 | C++                    | [borsh-cpp](https://github.com/Stolkerve/borsh-cpp) | *(work-in-progress)* |
 | C++20                    | [borsh-cpp20](https://github.com/israelidanny/borsh-cpp20) | *(work-in-progress)* |
 | Elixir                    | [borsh-ex](https://github.com/alexfilatov/borsh) | <a href="https://hex.pm/packages/borsh"><img src="https://img.shields.io/hexpm/v/borsh.svg?style=flat-square" alt="Latest released version" /></a> |
+| Ruby | [borsh.rb](https://github.com/dryruby/borsh.rb) | <a href="https://rubygems.org/gems/borsh"><img src="https://img.shields.io/gem/v/borsh?style=flat-square" alt="Latest released version" /></a> |
 
 ## Benchmarks
 


### PR DESCRIPTION
Needed a Borsh implementation in Ruby to support quick prototyping and scripting, so here goes.

Borsh.rb is now published on GitHub and RubyGems:
- https://github.com/dryruby/borsh.rb
- https://rubygems.org/gems/borsh

Borsh.rb is also used in the [RDF/Borsh](https://github.com/ruby-rdf/rdf-borsh) library for Ruby. Might be an idea to have a section on data formats layered **_on top of_** Borsh, but that's out of scope for this pull request.
